### PR TITLE
KVO removeObserver fix

### DIFF
--- a/JKTabBarController/_JKTabBarMoreViewController.h
+++ b/JKTabBarController/_JKTabBarMoreViewController.h
@@ -9,5 +9,5 @@
 #import <UIKit/UIKit.h>
 @class JKTabBarController;
 @interface _JKTabBarMoreViewController : UITableViewController
-@property (nonatomic,weak) JKTabBarController *tabBarController;
+@property (nonatomic,unsafe_unretained) JKTabBarController *tabBarController;
 @end


### PR DESCRIPTION
Weak reference to `JKTabBarController` is automatically `nil`ed when the tab bar controller dealloc. Thus in `-[_JKTabBarMoreViewController  dealloc]` the `self.tabBarController` is always nil.

Making `tabBarController` a `unsafe_unretained` reference resolved this issue.
